### PR TITLE
`ModuleNotFoundError: No module named 'marp_assist'` エラーを解決するため、Pytho…

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+# This file makes the 'backend' directory a Python package.

--- a/backend/database_setup.py
+++ b/backend/database_setup.py
@@ -3,7 +3,7 @@
 import uuid
 import psycopg2
 from psycopg2 import sql
-from marp_assist.infrastructure.database import db_session
+from .marp_assist.infrastructure.database import db_session
 
 def add_output_type_column():
     """


### PR DESCRIPTION
…nのパッケージ構造を修正しました。

`backend`ディレクトリがPythonからパッケージとして認識されていなかったことが根本的な原因でした。

修正内容は以下の通りです:
1. `backend/` ディレクトリに空の `__init__.py` ファイルを追加し、このディレクトリがパッケージであることを明示しました。
2. `backend/database_setup.py` 内のインポート文を、絶対インポートから相対インポート (`from .marp_assist...`) に変更しました。

これにより、`PYTHONPATH`のような環境変数に頼ることなく、`python -m backend.database_setup` コマンドでスクリプトを正しく実行できるようになります。