### PR TITLE
`python -m` でモジュールを実行した際の、複雑なパッケージ構造に起因する `ModuleNotFoundError` を解決しました。

### DIFF
--- a/backend/database_setup.py
+++ b/backend/database_setup.py
@@ -1,5 +1,14 @@
 # backend/database_setup.py
 
+import sys
+import os
+
+# database_setup.py の親ディレクトリ (backendディレクトリ) のパスを取得
+current_dir = os.path.dirname(os.path.abspath(__file__))
+# backendディレクトリをPythonの検索パスに追加
+if current_dir not in sys.path:
+    sys.path.insert(0, current_dir)
+
 import uuid
 import psycopg2
 from psycopg2 import sql

--- a/backend/marp_assist/application/services.py
+++ b/backend/marp_assist/application/services.py
@@ -3,7 +3,7 @@
 
 import google.generativeai as genai
 from ..infrastructure.repositories import TemplateRepository
-from ..config import config
+from config import config
 
 class PromptService:
     def __init__(self):

--- a/backend/marp_assist/infrastructure/database.py
+++ b/backend/marp_assist/infrastructure/database.py
@@ -2,7 +2,7 @@
 
 import psycopg2
 from contextlib import contextmanager
-from ..config import config
+from config import config
 
 def get_db_connection():
     """データベースへの接続を取得する"""


### PR DESCRIPTION
これまでの相対インポートによるアプローチでは、Pythonのパス解決の挙動が安定しなかったため、より堅牢な方法に切り替えました。

修正内容は以下の通りです:
1. `database.py` および `services.py` の `config` インポートを、シンプルな `from config import config` に戻しました。
2. エントリーポイントとなる `database_setup.py` の冒頭で、自身の親ディレクトリ (`backend`) を `sys.path` の先頭に動的に追加するロジックを挿入しました。

これにより、スクリプトの実行場所や方法に依存せず、常に `backend` ディレクトリがモジュール検索の対象となるため、`config.py` が安定して見つかるようになります。