### PR TITLE
アプリケーション起動時に発生していた `TypeError: Template.__init__() missing 1 required…

### DIFF
--- a/backend/marp_assist/infrastructure/repositories.py
+++ b/backend/marp_assist/infrastructure/repositories.py
@@ -6,54 +6,51 @@ from ..domain.models import Template
 from typing import List, Optional
 
 class TemplateRepository:
+    def _map_row_to_template(self, row) -> Template:
+        """DBの行データをTemplateオブジェクトにマッピングするヘルパー関数"""
+        return Template(
+            template_id=row[0],
+            template_name=row[1],
+            output_type=row[2],
+            persona=row[3],
+            tone_and_manner=row[4],
+            target_audience=row[5],
+            keywords=row[6],
+            banned_words=row[7]
+        )
+
     def get_all(self) -> List[Template]:
         """DBから全てのテンプレートを取得する"""
         templates = []
         with db_session() as conn:
             with conn.cursor() as cur:
-                # データベースのスキーマに合わせた正しいSQLクエリ
+                # output_type をSELECT文に追加
                 cur.execute("""
-                    SELECT template_id, template_name, persona, tone_and_manner, 
-                           target_audience, keywords, banned_words 
+                    SELECT template_id, template_name, output_type, persona,
+                           tone_and_manner, target_audience, keywords, banned_words
                     FROM templates 
                     ORDER BY created_at DESC
                 """)
                 rows = cur.fetchall()
                 for row in rows:
-                    # domain/models.pyのTemplateクラスに合わせてインスタンス化
-                    templates.append(Template(
-                        template_id=row[0],
-                        template_name=row[1],
-                        persona=row[2],
-                        tone_and_manner=row[3],
-                        target_audience=row[4],
-                        keywords=row[5],
-                        banned_words=row[6]
-                    ))
+                    # ヘルパー関数を使ってマッピング
+                    templates.append(self._map_row_to_template(row))
         return templates
 
     def find_by_name(self, name: str) -> Optional[Template]:
         """指定された名前のテンプレートを1件取得する (生成時に使用)"""
         with db_session() as conn:
             with conn.cursor() as cur:
-                # こちらもデータベースのスキーマに合わせた正しいSQLクエリ
+                # output_type をSELECT文に追加
                 cur.execute("""
-                    SELECT template_id, template_name, persona, tone_and_manner, 
-                           target_audience, keywords, banned_words 
+                    SELECT template_id, template_name, output_type, persona,
+                           tone_and_manner, target_audience, keywords, banned_words
                     FROM templates 
                     WHERE template_name = %s
                 """, (name,))
                 row = cur.fetchone()
                 if row:
-                    # domain/models.pyのTemplateクラスに合わせてインスタンス化
-                    return Template(
-                        template_id=row[0],
-                        template_name=row[1],
-                        persona=row[2],
-                        tone_and_manner=row[3],
-                        target_audience=row[4],
-                        keywords=row[5],
-                        banned_words=row[6]
-                    )
+                    # ヘルパー関数を使ってマッピング
+                    return self._map_row_to_template(row)
         return None
 


### PR DESCRIPTION
… positional argument: 'output_type'` を修正しました。

原因は、`TemplateRepository`がデータベースからデータを取得する際に`output_type`カラムをSELECTしておらず、`Template`ドメインモデルのインスタンス化で引数が不足していたためです。

修正内容は以下の通りです:
- `get_all`および`find_by_name`メソッド内の`SELECT`文に`output_type`を追加しました。
- データベースの行から`Template`オブジェクトへのマッピングロジックを修正し、すべての引数が正しい順序でコンストラクタに渡されるようにしました。
- マッピング処理を`_map_row_to_template`ヘルパーメソッドに切り出し、コードの可読性と保守性を向上させました。

この修正により、アプリケーションが正常に起動し、APIが正しく機能するようになります。