### PR TITLE
Refactor: Switch AI communication to Axon Gateway

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -12,6 +12,7 @@ class Config:
     DATABASE_URL = os.getenv("DATABASE_URL")
     GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
     MODEL_NAME = os.getenv("MODEL_NAME", 'gemini-2.5-pro') # .env にMODEL_NAMEを追加しても良い
+    AXON_GATEWAY_URL = os.getenv("AXON_GATEWAY_URL", "http://127.0.0.1:8001/api/v1/generate")
 
     DEBUG = os.getenv("DEBUG", "False").lower() == 'true'
     TESTING = os.getenv("TESTING", "False").lower() == 'true'

--- a/backend/marp_assist/application/services.py
+++ b/backend/marp_assist/application/services.py
@@ -1,20 +1,14 @@
 # ビジネスロジック（ユースケース）を担当します。
 # リポジトリからデータを取得し、プロンプトを組み立て、AIを呼び出します。
 
-import google.generativeai as genai
+import requests
 from ..infrastructure.repositories import TemplateRepository
 from config import config
 
 class PromptService:
     def __init__(self):
         self.template_repo = TemplateRepository()
-        # AIモデルの初期化
-        try:
-            genai.configure(api_key=config.GEMINI_API_KEY)
-            self.model = genai.GenerativeModel(config.MODEL_NAME)
-        except Exception as e:
-            print(f"AIモデルの初期化に失敗しました: {e}")
-            self.model = None
+        # AIモデルの初期化ロジックは不要になったため削除
 
     def get_all_templates(self):
         """全てのテンプレートの基本情報（名前とラベル）を取得する"""
@@ -23,11 +17,7 @@ class PromptService:
         return [{"name": t.template_name, "label": t.label} for t in templates]
 
     def generate_content(self, topic: str, template_name: str) -> str:
-        """指定されたトピックとテンプレート名でコンテンツを生成する"""
-        if not self.model:
-            raise Exception("AIモデルが利用できません。")
-
-        # template_repo.get_all() を find_by_name() に置き換えて効率化
+        """指定されたトピックとテンプレート名でコンテンツを生成する (Axon Gateway経由)"""
         target_template = self.template_repo.find_by_name(template_name)
 
         if not target_template:
@@ -45,8 +35,30 @@ class PromptService:
 
 以上の情報に基づき、コンテンツを生成してください。
 """
-        response = self.model.generate_content(prompt)
-        generated_text = response.text
+
+        # Axon AI Gatewayにリクエストを送信
+        try:
+            payload = {
+                "prompt": prompt,
+                "model": config.MODEL_NAME
+            }
+            response = requests.post(config.AXON_GATEWAY_URL, json=payload, timeout=60)
+            response.raise_for_status()  # HTTPエラーがあれば例外を発生させる
+
+            response_data = response.json()
+            generated_text = response_data.get("response")
+
+            if not generated_text:
+                raise Exception("AIからのレスポンスに 'response' キーが含まれていません。")
+
+        except requests.exceptions.RequestException as e:
+            # ネットワークエラーやタイムアウトなど
+            print(f"Axon Gatewayとの通信に失敗しました: {e}")
+            raise Exception("AIゲートウェイとの通信に失敗しました。")
+        except Exception as e:
+            # JSONデコードエラーやその他の予期せぬエラー
+            print(f"コンテンツ生成中に予期せぬエラーが発生しました: {e}")
+            raise
 
         # output_typeに応じて後処理を分岐
         if target_template.output_type == 'marp':

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
 flask
 python-dotenv
-google-generativeai
+requests
 Flask-Cors
 psycopg2-binary


### PR DESCRIPTION
This commit refactors the backend to use the new Axon AI Gateway for generating content, replacing the direct connection to the Google Gemini API.

Key changes:
- Replaced `google-generativeai` with `requests` in `requirements.txt`.
- Added `AXON_GATEWAY_URL` to the application configuration.
- Modified `PromptService` to send requests to the Axon Gateway endpoint.
- Removed the direct dependency on the `google.generativeai` library from the service layer.
- Added appropriate error handling for the new HTTP requests.