### PR TITLE
feat: スライド枚数とハッシュタグの制御機能を追加

### DIFF
--- a/backend/database_setup.py
+++ b/backend/database_setup.py
@@ -242,6 +242,36 @@ def insert_weekend_it_slides_template():
             conn.commit()
             print(f"✅ 新しいテンプレート '{template['template_name']}' を追加しました。")
 
+def add_slide_and_hashtag_columns():
+    """
+    templatesテーブルにslide_countとinclude_hashtagsカラムを追加する。
+    """
+    with db_session() as conn:
+        with conn.cursor() as cur:
+            # slide_countカラムの存在チェック
+            cur.execute("""
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name='templates' AND column_name='slide_count';
+            """)
+            if not cur.fetchone():
+                cur.execute("ALTER TABLE templates ADD COLUMN slide_count INTEGER NOT NULL DEFAULT 3;")
+                conn.commit()
+                print("✅ `slide_count`カラムを`templates`テーブルに追加しました。")
+            else:
+                print("ℹ️ `slide_count`カラムは既に存在します。")
+
+            # include_hashtagsカラムの存在チェック
+            cur.execute("""
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name='templates' AND column_name='include_hashtags';
+            """)
+            if not cur.fetchone():
+                cur.execute("ALTER TABLE templates ADD COLUMN include_hashtags BOOLEAN NOT NULL DEFAULT true;")
+                conn.commit()
+                print("✅ `include_hashtags`カラムを`templates`テーブルに追加しました。")
+            else:
+                print("ℹ️ `include_hashtags`カラムは既に存在します。")
+
 def main():
     """データベースのセットアップ処理を正しい順序で実行する"""
     print("データベースのセットアップを開始します...")
@@ -252,6 +282,7 @@ def main():
 
     # 2. テーブル構造を更新する
     add_theme_id_to_templates()
+    add_slide_and_hashtag_columns() # 新しいカラム追加処理を呼び出す
 
     # 3. 初期データを挿入する
     insert_sample_themes()

--- a/backend/marp_assist/application/services.py
+++ b/backend/marp_assist/application/services.py
@@ -12,10 +12,10 @@ class PromptService:
         self.theme_repo = ThemeRepository()
 
     def get_all_templates(self):
-        """全てのテンプレートの基本情報（名前とラベル）を取得する"""
+        """全てのテンプレートの基本情報（名前、ラベル、出力タイプ）を取得する"""
         templates = self.template_repo.get_all()
         # フロントエンドが必要な情報だけを辞書のリストに変換
-        return [{"name": t.template_name, "label": t.label} for t in templates]
+        return [{"name": t.template_name, "label": t.label, "output_type": t.output_type} for t in templates]
 
     def get_all_themes(self):
         """全てのテーマの基本情報（IDと名前）を取得する"""
@@ -23,14 +23,55 @@ class PromptService:
         # フロントエンドが必要な情報だけを辞書のリストに変換
         return [{"id": t.theme_id, "name": t.theme_name} for t in themes]
 
-    def generate_content(self, topic: str, template_name: str, theme_id: Optional[int] = None) -> str:
-        """指定された情報でコンテンツを生成する"""
+    def generate_content(self, topic: str, template_name: str, theme_id: Optional[int] = None, slide_count: Optional[int] = None, include_hashtags: Optional[bool] = None) -> str:
+        """
+        指定された情報でコンテンツを生成する。
+        プロンプトの組み立てロジックもこのメソッド内で担当する。
+        """
         target_template = self.template_repo.find_by_name(template_name)
 
         if not target_template:
             raise ValueError(f"テンプレート '{template_name}' が見つかりません。")
 
-        # プロンプトを組み立てる
+        # --- プロンプト条件の組み立て ---
+        conditions_parts = []
+        if target_template.output_type == 'tweet':
+            conditions_parts.append("# 投稿文の生成条件")
+            if target_template.tone_and_manner:
+                conditions_parts.append(f"- 文章のトーン＆マナー: {target_template.tone_and_manner}")
+            if target_template.target_audience:
+                conditions_parts.append(f"- ターゲット読者: {target_template.target_audience}")
+            if target_template.keywords:
+                keyword_str = ", ".join(target_template.keywords)
+                conditions_parts.append(f"- 含めるべきキーワード: {keyword_str}")
+            if target_template.banned_words:
+                banned_word_str = ", ".join(target_template.banned_words)
+                conditions_parts.append(f"- 含めてはいけないキーワード: {banned_word_str}")
+            conditions_parts.append("- 必ず140文字以内で、提案を3案作成してください。")
+
+        elif target_template.output_type == 'marp':
+            conditions_parts.append("# Marpスライド原稿の生成条件")
+
+            # スライド枚数を指定（リクエストの値 > DBのデフォルト値）
+            final_slide_count = slide_count if slide_count is not None else target_template.slide_count
+            conditions_parts.append(f"- スライドを{final_slide_count}枚構成で作成してください。")
+
+            conditions_parts.append("- 1枚目がタイトル、最後の1枚がまとめのスライドになるようにしてください。")
+            conditions_parts.append("- 各スライドは`---`で区切ってください。")
+            conditions_parts.append("- スライドのタイトルは`#`、箇条書きは`-`や`*`を使ってMarkdown形式で記述してください。")
+            conditions_parts.append("- コードを記述する場合は、適切な言語名を指定したコードブロックを使用してください。例: ```python ... ```")
+            if target_template.keywords:
+                keyword_str = ", ".join(target_template.keywords)
+                conditions_parts.append(f"- 含めるべきキーワード: {keyword_str}")
+
+            # ハッシュタグの有無を制御（リクエストの値 > DBのデフォルト値）
+            final_include_hashtags = include_hashtags if include_hashtags is not None else target_template.include_hashtags
+            if not final_include_hashtags:
+                conditions_parts.append("- ハッシュタグは絶対に含めないでください。")
+
+        conditions = "\n".join(conditions_parts)
+        # --- プロンプト条件の組み立て完了 ---
+
         prompt = f"""
 {target_template.persona}
 
@@ -38,7 +79,7 @@ class PromptService:
 {topic}
 
 # 条件
-{target_template.conditions}
+{conditions}
 
 以上の情報に基づき、コンテンツを生成してください。
 """
@@ -50,7 +91,7 @@ class PromptService:
                 "model": config.MODEL_NAME
             }
             response = requests.post(config.AXON_GATEWAY_URL, json=payload, timeout=60)
-            response.raise_for_status()  # HTTPエラーがあれば例外を発生させる
+            response.raise_for_status()
 
             response_data = response.json()
             generated_text = response_data.get("response")
@@ -59,11 +100,9 @@ class PromptService:
                 raise Exception("AIからのレスポンスに 'response' キーが含まれていません。")
 
         except requests.exceptions.RequestException as e:
-            # ネットワークエラーやタイムアウトなど
             print(f"Axon Gatewayとの通信に失敗しました: {e}")
             raise Exception("AIゲートウェイとの通信に失敗しました。")
         except Exception as e:
-            # JSONデコードエラーやその他の予期せぬエラー
             print(f"コンテンツ生成中に予期せぬエラーが発生しました: {e}")
             raise
 
@@ -75,11 +114,7 @@ class PromptService:
                 if theme:
                     marp_config = theme.marp_config + "\n\n---\n\n"
                 else:
-                    # 指定されたtheme_idが見つからない場合、警告を出すかデフォルトに倒す
                     print(f"警告: 指定されたtheme_id {theme_id} が見つかりませんでした。")
-
-            # Marpの場合は、設定情報を先頭に結合する
             return marp_config + generated_text
         else:
-            # それ以外の場合は、生成されたテキストをそのまま返す
             return generated_text

--- a/backend/marp_assist/domain/models.py
+++ b/backend/marp_assist/domain/models.py
@@ -23,42 +23,7 @@ class Template:
     target_audience: Optional[str]
     keywords: Optional[List[str]]
     banned_words: Optional[List[str]]
-    theme_id: Optional[int]  # テーマIDを追加
-    conditions: str = field(init=False)
-
-    def __post_init__(self):
-        """
-        オブジェクト初期化後に、DBの各カラムから
-        AIへの指示となるconditions文字列を自動的に組み立てる。
-        output_typeに応じて、組み立てる内容を切り替える。
-        """
-        conditions_parts = []
-        if self.output_type == 'tweet':
-            conditions_parts.append("# 投稿文の生成条件")
-            if self.tone_and_manner:
-                conditions_parts.append(f"- 文章のトーン＆マナー: {self.tone_and_manner}")
-            if self.target_audience:
-                conditions_parts.append(f"- ターゲット読者: {self.target_audience}")
-            if self.keywords:
-                keyword_str = ", ".join(self.keywords)
-                conditions_parts.append(f"- 含めるべきキーワード: {keyword_str}")
-            if self.banned_words:
-                banned_word_str = ", ".join(self.banned_words)
-                conditions_parts.append(f"- 含めてはいけないキーワード: {banned_word_str}")
-
-            # デフォルトの指示を追加
-            conditions_parts.append("- 必ず140文字以内で、提案を3案作成してください。")
-
-        elif self.output_type == 'marp':
-            conditions_parts.append("# Marpスライド原稿の生成条件")
-            conditions_parts.append("- 全体は5〜7枚程度のスライドで構成してください。")
-            conditions_parts.append("- 1枚目がタイトル、最後の1枚がまとめのスライドになるようにしてください。")
-            conditions_parts.append("- 各スライドは`---`で区切ってください。")
-            conditions_parts.append("- スライドのタイトルは`#`、箇条書きは`-`や`*`を使ってMarkdown形式で記述してください。")
-            conditions_parts.append("- コードを記述する場合は、適切な言語名を指定したコードブロックを使用してください。例: ```python ... ```")
-            if self.keywords:
-                keyword_str = ", ".join(self.keywords)
-                conditions_parts.append(f"- 含めるべきキーワード: {keyword_str}")
-
-        self.conditions = "\n".join(conditions_parts)
+    theme_id: Optional[int]
+    slide_count: int
+    include_hashtags: bool
 

--- a/backend/marp_assist/infrastructure/repositories.py
+++ b/backend/marp_assist/infrastructure/repositories.py
@@ -47,7 +47,9 @@ class TemplateRepository:
             target_audience=row['target_audience'],
             keywords=row['keywords'],
             banned_words=row['banned_words'],
-            theme_id=row.get('theme_id') # NULLの場合があるので .get() を使用
+            theme_id=row.get('theme_id'), # NULLの場合があるので .get() を使用
+            slide_count=row['slide_count'],
+            include_hashtags=row['include_hashtags']
         )
 
     def get_all(self) -> List[Template]:

--- a/backend/marp_assist/presentation/routes.py
+++ b/backend/marp_assist/presentation/routes.py
@@ -74,10 +74,18 @@ def generate():
 
     topic = data['topic']
     template_name = data['template_name']
-    theme_id = data.get('theme_id') # theme_idはオプショナル
+    theme_id = data.get('theme_id')
+    slide_count = data.get('slide_count')
+    include_hashtags = data.get('include_hashtags')
 
     try:
-        content = prompt_service.generate_content(topic, template_name, theme_id)
+        content = prompt_service.generate_content(
+            topic=topic,
+            template_name=template_name,
+            theme_id=theme_id,
+            slide_count=slide_count,
+            include_hashtags=include_hashtags
+        )
         return jsonify({"content": content})
     except ValueError as e:
         return jsonify({"error": str(e)}), 404

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -34,6 +34,17 @@
         </div>
     </div>
 
+    <div id="marp-options-container" style="display: none; margin-bottom: 1em; display: flex; gap: 20px; align-items: center;">
+        <div>
+            <label for="slide-count-input">スライド枚数:</label>
+            <input type="number" id="slide-count-input" value="5" min="1" max="20" style="width: 60px;">
+        </div>
+        <div>
+            <input type="checkbox" id="include-hashtags-checkbox" checked>
+            <label for="include-hashtags-checkbox">ハッシュタグを含める</label>
+        </div>
+    </div>
+
     <textarea id="topic-input" placeholder="例：テレワークの生産性を上げる3つのコツ"></textarea>
     <button id="generate-button">Marp原稿を生成する</button>
 

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -4,19 +4,25 @@ document.addEventListener('DOMContentLoaded', () => {
     const generateButton = document.getElementById('generate-button');
     const copyButton = document.getElementById('copy-button');
     const downloadPdfButton = document.getElementById('download-pdf-button');
-    const resultTextarea = document.getElementById('result-textarea'); // <pre>から<textarea>に変更
+    const resultTextarea = document.getElementById('result-textarea');
     const templateSelect = document.getElementById('template-select');
-    const themeSelect = document.getElementById('theme-select'); // テーマ選択用に追加
+    const themeSelect = document.getElementById('theme-select');
+    const marpOptionsContainer = document.getElementById('marp-options-container');
+    const slideCountInput = document.getElementById('slide-count-input');
+    const includeHashtagsCheckbox = document.getElementById('include-hashtags-checkbox');
 
     // バックエンドAPIのURL
     const API_BASE_URL = '/api';
     const GENERATE_API_URL = `${API_BASE_URL}/generate`;
     const DOWNLOAD_PDF_API_URL = `${API_BASE_URL}/download_pdf`;
     const TEMPLATES_API_URL = `${API_BASE_URL}/templates`;
-    const THEMES_API_URL = `${API_BASE_URL}/themes`; // テーマAPI用に追加
+    const THEMES_API_URL = `${API_BASE_URL}/themes`;
 
     // コピーボタンの初期のテキスト
     const originalCopyButtonText = copyButton.textContent;
+
+    // テンプレート情報を保持する変数
+    let allTemplates = [];
 
     // テンプレートをバックエンドから取得してドロップダウンを生成する関数
     async function populateTemplates() {
@@ -25,13 +31,16 @@ document.addEventListener('DOMContentLoaded', () => {
             if (!response.ok) {
                 throw new Error('テンプレートの読み込みに失敗しました。');
             }
-            const templates = await response.json();
-            templates.forEach(template => {
+            allTemplates = await response.json(); // テンプレート情報を保持
+            templateSelect.innerHTML = ''; // 一旦クリア
+            allTemplates.forEach(template => {
                 const option = document.createElement('option');
                 option.value = template.name;
                 option.textContent = template.label;
                 templateSelect.appendChild(option);
             });
+            // 初期表示のためにchangeイベントを発火
+            templateSelect.dispatchEvent(new Event('change'));
         } catch (error) {
             console.error('Error fetching templates:', error);
             alert(error.message);
@@ -48,8 +57,8 @@ document.addEventListener('DOMContentLoaded', () => {
             const themes = await response.json();
             themes.forEach(theme => {
                 const option = document.createElement('option');
-                option.value = theme.id; // valueをidに
-                option.textContent = theme.name; // textをnameに
+                option.value = theme.id;
+                option.textContent = theme.name;
                 themeSelect.appendChild(option);
             });
         } catch (error) {
@@ -57,6 +66,17 @@ document.addEventListener('DOMContentLoaded', () => {
             alert(error.message);
         }
     }
+
+    // テンプレート選択の変更イベント
+    templateSelect.addEventListener('change', () => {
+        const selectedTemplateName = templateSelect.value;
+        const selectedTemplate = allTemplates.find(t => t.name === selectedTemplateName);
+        if (selectedTemplate && selectedTemplate.output_type === 'marp') {
+            marpOptionsContainer.style.display = 'flex';
+        } else {
+            marpOptionsContainer.style.display = 'none';
+        }
+    });
 
     // ページ読み込み時にテンプレートとテーマを取得
     populateTemplates();
@@ -66,7 +86,7 @@ document.addEventListener('DOMContentLoaded', () => {
     generateButton.addEventListener('click', async () => {
         const topic = topicInput.value;
         const templateName = templateSelect.value;
-        const themeId = themeSelect.value; // 選択されたテーマIDを取得
+        const themeId = themeSelect.value;
 
         if (!topic.trim()) {
             alert('お題を入力してください。');
@@ -77,25 +97,31 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
 
-        // ボタンを無効化し、ローディング表示
         generateButton.disabled = true;
         downloadPdfButton.disabled = true;
-        resultTextarea.value = 'AIが生成中です...'; // .textContentから.valueへ変更
+        resultTextarea.value = 'AIが生成中です...';
         resultTextarea.classList.add('loading');
 
+        // リクエストボディを構築
+        const requestBody = {
+            topic: topic,
+            template_name: templateName,
+            theme_id: parseInt(themeId, 10)
+        };
+
+        // Marpオプションが表示されている場合、値を追加
+        if (marpOptionsContainer.style.display !== 'none') {
+            requestBody.slide_count = parseInt(slideCountInput.value, 10);
+            requestBody.include_hashtags = includeHashtagsCheckbox.checked;
+        }
+
         try {
-            // バックエンドAPIにリクエストを送信
             const response = await fetch(GENERATE_API_URL, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
                 },
-                // topic, template_name, theme_idを送信
-                body: JSON.stringify({
-                    topic: topic,
-                    template_name: templateName,
-                    theme_id: parseInt(themeId, 10) // 数値として送信
-                }),
+                body: JSON.stringify(requestBody),
             });
 
             if (!response.ok) {
@@ -104,7 +130,7 @@ document.addEventListener('DOMContentLoaded', () => {
             }
 
             const data = await response.json();
-            resultTextarea.value = data.content; // .textContentから.valueへ変更
+            resultTextarea.value = data.content;
             downloadPdfButton.disabled = false;
 
         } catch (error) {


### PR DESCRIPTION
Marpスライド生成時に、あなたがスライド枚数を指定し、ハッシュタグの有無を制御できるようにする新機能を追加します。

- DB: `templates`テーブルに`slide_count`と`include_hashtags`カラムを追加。
- Backend: プロンプト生成ロジックをサービス層に移動し、動的な値（スライド枚数、ハッシュタグ有無）を反映できるようにリファクタリング。
- Frontend: Marpテンプレート選択時のみに表示される専用のオプションUI（数値入力、チェックボックス）を追加。選択された値をAPIリクエストに含めるように修正。